### PR TITLE
Переход на PDO для php >= 5.6

### DIFF
--- a/source/nekoBackup/Builder/MySQL.php
+++ b/source/nekoBackup/Builder/MySQL.php
@@ -27,17 +27,16 @@ class MySQL extends AbstractBuilder
 
   protected function getDatabaseList(&$config)
   {
-    if(!($conn = mysql_connect($config['hostname'], $config['username'], $config['password']))){
-      throw new \Exception('Cannot connect to mysql server!');
-    }
+    $dbh = new \PDO('mysql:host=' . $config['hostname'], $config['username'], $config['password']);
 
-    if(!($res = mysql_query('show databases', $conn))) {
+    $dbs = $dbh->query('show databases');
+    if ($dbs === false) {
       throw new \Exception('Cannot read database list');
     }
 
     $list = array();
-    while($row = mysql_fetch_assoc($res)) {
-      $list[] = $row['Database'];
+    while( ( $db = $dbs->fetchColumn( 0 ) ) !== false ) {
+      $list[] = $db;
     }
 
 //    $exclude_tables = array();


### PR DESCRIPTION
Фикс, чтобы избавиться от нотиса в php >= 5.6

```
[28-May-2015 00:51:03 Europe/Moscow] PHP Deprecated:  mysql_connect(): The mysql extension is deprecated and will be removed in the future: use mysqli or PDO instead in /opt/nbackup2/source/nekoBackup/Builder/MySQL.php on line 30
```
